### PR TITLE
Fixed formatting issue in education section of Template 9 (Issue #100)

### DIFF
--- a/app/server/src/generator/templates/template9/index.js
+++ b/app/server/src/generator/templates/template9/index.js
@@ -83,7 +83,8 @@ const generator: Template9Generator = {
           \\EducationEntry
             {${degreeLine}}
             {${dateRange || ''}}
-            {${nameLine}${i < lastSchoolIndex ? '\\\\' : ''}}
+            {${nameLine}}
+            ${i < lastSchoolIndex ? '\\sepspace' : ''}
         `
       })}
     `


### PR DESCRIPTION
See title. Small issue where entering more than one school caused formatting issues/failure to render pdf. Also swapped a \\ for sepspace which is consistent with the rest of the sections in template 9