### PR TITLE
Add logging to the backend

### DIFF
--- a/app/server/package-lock.json
+++ b/app/server/package-lock.json
@@ -176,6 +176,15 @@
         "@types/koa": "*"
       }
     },
+    "@types/koa-logger": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/koa-logger/-/koa-logger-3.1.1.tgz",
+      "integrity": "sha512-wp2HaskkPugfwgXgNnc+idnReuJZSTTYQbkcxXjsMhp1kTc342PxDzTL9FXDgBfEvgt9NX1CCGjkwPKX2dlEKQ==",
+      "dev": true,
+      "requires": {
+        "@types/koa": "*"
+      }
+    },
     "@types/koa__router": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@types/koa__router/-/koa__router-8.0.2.tgz",
@@ -832,6 +841,11 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
     "expect-ct": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/expect-ct/-/expect-ct-0.2.0.tgz",
@@ -954,8 +968,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-yarn": {
       "version": "2.1.0",
@@ -1059,6 +1072,11 @@
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.0"
       }
+    },
+    "humanize-number": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/humanize-number/-/humanize-number-0.0.2.tgz",
+      "integrity": "sha1-EcCvakcWQ2M1iFiASPF5lUFInBg="
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -1333,6 +1351,50 @@
         "helmet": "^3.21.1"
       }
     },
+    "koa-logger": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/koa-logger/-/koa-logger-3.2.1.tgz",
+      "integrity": "sha512-MjlznhLLKy9+kG8nAXKJLM0/ClsQp/Or2vI3a5rbSQmgl8IJBQO0KI5FA70BvW+hqjtxjp49SpH2E7okS6NmHg==",
+      "requires": {
+        "bytes": "^3.1.0",
+        "chalk": "^2.4.2",
+        "humanize-number": "0.0.2",
+        "passthrough-counter": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+        }
+      }
+    },
     "latest-version": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-5.1.0.tgz",
@@ -1579,6 +1641,11 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
       "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+    },
+    "passthrough-counter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passthrough-counter/-/passthrough-counter-1.0.0.tgz",
+      "integrity": "sha1-GWfZ5m2lcrXAI8eH2xEqOHqxZvo="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -1886,7 +1953,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "tsc",
-    "start": "nodemon --watch 'src/**/*.ts' --exec 'ts-node' src/index.ts"
+    "start": "nodemon --watch 'src/**/*.ts' --exec ts-node src/index.ts"
   },
   "dependencies": {
     "@koa/router": "^9.0.1",

--- a/app/server/package.json
+++ b/app/server/package.json
@@ -14,6 +14,7 @@
     "koa": "^2.12.0",
     "koa-bodyparser": "^4.3.0",
     "koa-helmet": "^5.2.0",
+    "koa-logger": "^3.2.1",
     "node-latex": "^3.0.0",
     "pretty-latex": "^0.1.0",
     "sanitize-latex": "^1.0.0"
@@ -23,6 +24,7 @@
     "@types/common-tags": "^1.8.0",
     "@types/koa": "^2.11.3",
     "@types/koa-bodyparser": "^4.3.0",
+    "@types/koa-logger": "^3.1.1",
     "@types/koa__router": "^8.0.2",
     "nodemon": "^2.0.4",
     "prettier": "^2.0.5",

--- a/app/server/src/index.ts
+++ b/app/server/src/index.ts
@@ -1,11 +1,13 @@
 import Koa from 'koa'
 import bodyParser from 'koa-bodyparser'
+import logger from 'koa-logger'
 import { api } from './routes/api'
 import { errorHandler } from './middleware/error-handler'
 
 const app = new Koa()
 const port = process.env.PORT || 4001
 
+app.use(logger())
 app.use(errorHandler())
 app.use(bodyParser())
 app.use(api.routes())


### PR DESCRIPTION
It currently hard to know whether any work is happening in the Backend. This PR attempts to fix that by adding `koa-logger` at the top of middleware chain.