### PR TITLE
Add a button to move education fields

### DIFF
--- a/src/components/common/Card.tsx
+++ b/src/components/common/Card.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react'
+import { ReactNode, SyntheticEvent } from 'react'
 import styled from 'styled-components'
 import { colors, sizes } from '../../theme'
 
@@ -7,6 +7,34 @@ const CloseButton = styled.button`
   position: absolute;
   top: 0;
   right: 0;
+  padding: 0.75rem;
+  cursor: pointer;
+  outline: none;
+  border: 0;
+  border-top-right-radius: 10px;
+  border-bottom-left-radius: 10px;
+  background: ${colors.black};
+  color: ${colors.primary};
+  box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.5);
+`
+const UpButton = styled.button`
+  position: absolute;
+  top: 0;
+  right: 60px;
+  padding: 0.75rem;
+  cursor: pointer;
+  outline: none;
+  border: 0;
+  border-top-right-radius: 10px;
+  border-bottom-left-radius: 10px;
+  background: ${colors.black};
+  color: ${colors.primary};
+  box-shadow: 0px 0px 3px rgba(0, 0, 0, 0.5);
+`
+const DownButton = styled.button`
+  position: absolute;
+  top: 0;
+  right: 30px;
   padding: 0.75rem;
   cursor: pointer;
   outline: none;
@@ -46,12 +74,30 @@ const Wrapper = styled.div`
 interface Props {
   children: ReactNode
   removeCard?: () => void
+  moveUp?: () => void
+  moveDown?: () => void
 }
 
-export function Card({ children, removeCard }: Props) {
+/**
+ * Adds a prevent default just before the function call
+ * @param callback The action to execute after the preventDefault
+ */
+function prependPreventDefault(callback: () => void) {
+  return (event: SyntheticEvent<HTMLButtonElement>) => {
+    event.preventDefault()
+    callback()
+  }
+}
+
+export function Card({ children, removeCard, moveUp, moveDown }: Props) {
   return (
     <Wrapper>
       {children}
+      {/* prepending preventDefault to a click callback is needed due to element swaps, these can rerender the entire form tree if we don't call it */}
+      {moveUp && <UpButton onClick={prependPreventDefault(moveUp)}>↑</UpButton>}
+      {moveDown && (
+        <DownButton onClick={prependPreventDefault(moveDown)}>↓</DownButton>
+      )}
       {removeCard && <CloseButton onClick={removeCard}>X</CloseButton>}
     </Wrapper>
   )

--- a/src/components/generator/form/sections/EducationSection.tsx
+++ b/src/components/generator/form/sections/EducationSection.tsx
@@ -5,14 +5,24 @@ import { LabeledInput } from '../inputs/LabeledInput'
 import { FormValues } from '../../../../types'
 
 export function EducationSection() {
-  const { fields, append, remove } = useFieldArray<FormValues, 'education'>({
+  const { fields, append, remove, swap } = useFieldArray<
+    FormValues,
+    'education'
+  >({
     name: 'education'
   })
 
   return (
     <FormSection title="Your Educational Background">
       {fields.map((field, index) => (
-        <Card key={field.id} removeCard={() => remove(index)}>
+        <Card
+          key={field.id}
+          removeCard={() => remove(index)}
+          moveUp={index >= 1 ? () => swap(index - 1, index) : undefined}
+          moveDown={
+            index < fields.length - 1 ? () => swap(index + 1, index) : undefined
+          }
+        >
           <LabeledInput
             name={`education.${index}.institution`}
             label="School name"


### PR DESCRIPTION
I think it would be cool to have a quick button to move up education fields so you can quickly swap educations. It would also be cool to translate this to other forms. Here is a screenshot of the implementation:
<img width="528" alt="image" src="https://user-images.githubusercontent.com/24482526/203876486-c3681257-0edf-45ab-baef-b20f458c4c03.png">
<img width="548" alt="image" src="https://user-images.githubusercontent.com/24482526/203876500-4ed0ad86-5a0b-4fb1-8d5b-349a485512fa.png">
After clicking the up button it moves up. 

I think the CSS and design could get so much better ofc. If this is something that is interesting we could improve how it looks.