### PR TITLE
Ability to Resort Job Items

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [saadq]

--- a/app/client/src/app/pages/Error404.js
+++ b/app/client/src/app/pages/Error404.js
@@ -4,7 +4,6 @@
 
 import React from 'react'
 import styled from 'styled-components'
-import { darken, rgba } from 'polished'
 import { PrimaryButton } from '../../common/components'
 import { colors } from '../../common/theme'
 import comic from '../assets/comic.png'

--- a/app/client/src/features/form/actions.js
+++ b/app/client/src/features/form/actions.js
@@ -186,6 +186,19 @@ function removeAward(): Action {
   }
 }
 
+function moveJobUp(index: number): Action {
+  return {
+    type: 'MOVE_JOB_UP',
+    index
+  }
+}
+function moveJobDown(index: number): Action {
+  return {
+    type: 'MOVE_JOB_DOWN',
+    index
+  }
+}
+
 export {
   uploadJSON,
   uploadJSONRequest,
@@ -210,5 +223,7 @@ export {
   removeProjectKeyword,
   addAward,
   removeAward,
-  uploadFileAndGenerateResume
+  uploadFileAndGenerateResume,
+  moveJobUp,
+  moveJobDown
 }

--- a/app/client/src/features/form/components/fragments/Job.js
+++ b/app/client/src/features/form/components/fragments/Job.js
@@ -32,13 +32,43 @@ type Props = {
   highlights: Array<?string>,
   index: number,
   addHighlight: (index: number) => void,
-  removeHighlight: (index: number) => void
+  removeHighlight: (index: number) => void,
+  jobCount: number,
+  moveUp: (index: number) => void,
+  moveDown: (index: number) => void
 }
 
-function Job({ highlights, index, addHighlight, removeHighlight }: Props) {
+function Job({
+  highlights,
+  index,
+  addHighlight,
+  removeHighlight,
+  jobCount,
+  moveUp,
+  moveDown
+}: Props) {
   return (
     <div>
       {index > 0 ? <Divider /> : null}
+      <Row>
+        <Label>Move job position</Label>
+        <ButtonRow>
+          <RoundButton
+            disabled={index === 0}
+            type="button"
+            onClick={() => moveUp(index)}
+          >
+            <Icon type="arrow_upward" />
+          </RoundButton>
+          <RoundButton
+            disabled={index >= jobCount - 1}
+            type="button"
+            onClick={() => moveDown(index)}
+          >
+            <Icon type="arrow_downward" />
+          </RoundButton>
+        </ButtonRow>
+      </Row>
       <LabeledInput
         name={`work[${index}].company`}
         label="Company Name"

--- a/app/client/src/features/form/components/sections/Work.js
+++ b/app/client/src/features/form/components/sections/Work.js
@@ -12,7 +12,9 @@ import {
   addJob,
   removeJob,
   addJobHighlight,
-  removeJobHighlight
+  removeJobHighlight,
+  moveJobUp,
+  moveJobDown
 } from '../../actions'
 import type { FormValues } from '../../types'
 import type { State } from '../../../../app/types'
@@ -24,15 +26,20 @@ type Props = {
   addJob: () => void,
   removeJob: () => void,
   addJobHighlight: (index: number) => void,
-  removeJobHighlight: (index: number) => void
+  removeJobHighlight: (index: number) => void,
+  moveJobUp: (index: number) => void,
+  moveJobDown: (index: number) => void
 }
 
 function Work({
   work,
+  jobCount = work.length,
   addJob,
   removeJob,
   addJobHighlight,
-  removeJobHighlight
+  removeJobHighlight,
+  moveJobUp,
+  moveJobDown
 }: Props) {
   return (
     <Section heading="Your Work Experience">
@@ -49,6 +56,9 @@ function Work({
           highlights={job.highlights}
           addHighlight={addJobHighlight}
           removeHighlight={removeJobHighlight}
+          jobCount={jobCount}
+          moveUp={moveJobUp}
+          moveDown={moveJobDown}
         />
       ))}
       <Button onClick={addJob} type="button">
@@ -71,7 +81,9 @@ const mapActions = {
   addJob,
   removeJob,
   addJobHighlight,
-  removeJobHighlight
+  removeJobHighlight,
+  moveJobUp,
+  moveJobDown
 }
 
 export default connect(mapState, mapActions)(Work)

--- a/app/client/src/features/form/reducer.js
+++ b/app/client/src/features/form/reducer.js
@@ -406,6 +406,47 @@ function form(state: FormState = initialState, action: Action): FormState {
       }
     }
 
+    case 'MOVE_JOB_UP': {
+      if (state.values.work.length <= 1 || action.index <= 0) {
+        return state
+      }
+
+      return {
+        ...state,
+        values: {
+          ...state.values,
+          work: [
+            ...state.values.work.slice(0, action.index - 1),
+            state.values.work[action.index],
+            state.values.work[action.index - 1],
+            ...state.values.work.slice(action.index + 1)
+          ]
+        }
+      }
+    }
+
+    case 'MOVE_JOB_DOWN': {
+      if (
+        state.values.work.length <= 1 ||
+        action.index + 1 >= state.values.work.length
+      ) {
+        return state
+      }
+
+      return {
+        ...state,
+        values: {
+          ...state.values,
+          work: [
+            ...state.values.work.slice(0, action.index),
+            state.values.work[action.index + 1],
+            state.values.work[action.index],
+            ...state.values.work.slice(action.index + 2)
+          ]
+        }
+      }
+    }
+
     default:
       return state
   }

--- a/app/client/src/features/form/types.js
+++ b/app/client/src/features/form/types.js
@@ -110,5 +110,7 @@ type FormAction =
   | { type: 'REMOVE_PROJECT_KEYWORD', index: number }
   | { type: 'ADD_AWARD' }
   | { type: 'REMOVE_AWARD' }
+  | { type: 'MOVE_JOB_UP', index: number }
+  | { type: 'MOVE_JOB_DOWN', index: number }
 
 export type { FormState, FormAction, FormValues, FormValuesWithSectionOrder }

--- a/app/server/src/generator/templates/template1/index.js
+++ b/app/server/src/generator/templates/template1/index.js
@@ -342,6 +342,8 @@ function template1(values: SanitizedValues) {
     \\textheight=10in
     \\pagestyle{empty}
     \\raggedright
+    \\usepackage[bottom=0.8in,top=0.8in]{geometry}
+
 
     ${generator.resumeDefinitions()}
 

--- a/app/server/src/generator/templates/template1/index.js
+++ b/app/server/src/generator/templates/template1/index.js
@@ -342,8 +342,7 @@ function template1(values: SanitizedValues) {
     \\textheight=10in
     \\pagestyle{empty}
     \\raggedright
-    \\usepackage[bottom=0.8in,top=0.8in]{geometry}
-
+    \\usepackage[left=0.8in,right=0.8in,bottom=0.8in,top=0.8in]{geometry}
 
     ${generator.resumeDefinitions()}
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 # Important Note
 
-All development is currently happening in the Resumake rewrite which is in the [v3](https://github.com/saadq/resumake.io/tree/v3) branch. In the mean time, no further development/fixes will be done in the current app in order to focus efforts on the next version.
+All development is currently happening in the Resumake rewrite which is in the [v3](https://github.com/saadq/resumake.io/tree/main) branch. In the mean time, no further development/fixes will be done in the current app in order to focus efforts on the next version.
 
 ---
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 
 # Important Note
 
-All development is currently happening in the Resumake rewrite which is in the [v3](https://github.com/saadq/resumake.io/tree/main) branch. In the mean time, no further development/fixes will be done in the current app in order to focus efforts on the next version.
+All development is currently happening in the Resumake rewrite which is in the [main](https://github.com/saadq/resumake.io/tree/main) branch. In the mean time, no further development/fixes will be done in the current app in order to focus efforts on the next version.
 
 ---
 


### PR DESCRIPTION
In the Work section we can now resort job items

Summary of Changes:
Implemented two new actions to move jobs up and down within the work array:
MOVE_JOB_UP: Moves the job at the specified index one position up in the list.
MOVE_JOB_DOWN: Moves the job at the specified index one position down in the list.